### PR TITLE
useEffect to clear app when utilityAccountId changes

### DIFF
--- a/src/components/utility-account-form.jsx
+++ b/src/components/utility-account-form.jsx
@@ -13,7 +13,7 @@ const UtilityAccountForm = ({arcUtilityAccountId, setArcUtilityAccountId, genabi
   // Clear the current Genability Account if the user re-enters a arcUtilityAccountId
   useEffect(() => {
     setGenabilityAccount(null)
-  }, [arcUtilityAccountId]);
+  }, [arcUtilityAccountId, setGenabilityAccount]);
 
   return (
     <div>

--- a/src/components/utility-account-form.jsx
+++ b/src/components/utility-account-form.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { createGenabilityAccount } from "../session.js";
 import JSONPretty from 'react-json-pretty';
 import { func, string, object } from 'prop-types';
@@ -8,6 +9,11 @@ const UtilityAccountForm = ({arcUtilityAccountId, setArcUtilityAccountId, genabi
     const result = await createGenabilityAccount(arcUtilityAccountId);
     setGenabilityAccount(result)
   };
+
+  // Clear the current Genability Account if the user re-enters a arcUtilityAccountId
+  useEffect(() => {
+    setGenabilityAccount(null)
+  }, [arcUtilityAccountId]);
 
   return (
     <div>

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -15,6 +15,8 @@ const customStyles = {
   },
 };
 
+Modal.setAppElement(document.getElementById('root'));
+
 const UtilityStatementElement = ({arcUtilityStatement}) => {
   const [openModal, setOpenModal] = useState(false)
 
@@ -33,7 +35,7 @@ const UtilityStatementElement = ({arcUtilityStatement}) => {
       <button onClick={() => calculate(arcUtilityStatement.id)}>
         Calculate Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}
       </button>
-      <Modal isOpen={openModal} style={customStyles}>
+      <Modal isOpen={openModal} style={customStyles} appElement={document.getElementById('app')}>
         <p> We will display the results here if the exist and present loading if they are loading</p>
         <button onClick={closeModal}>close</button>
       </Modal>

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -3,7 +3,6 @@ import JSONPretty from 'react-json-pretty';
 import { calculateCounterfactualBill } from "../session.js";
 import { object } from 'prop-types';
 import Modal from 'react-modal';
-import CalculationModal from './calculation-modal.jsx'
 
 const customStyles = {
   content: {

--- a/src/components/utility-statements-display.jsx
+++ b/src/components/utility-statements-display.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { fetchUtilityStatements } from "../session.js";
 import UtilityStatementElement from "./utility-statement-element.jsx";
 import { string } from 'prop-types';
@@ -10,6 +10,11 @@ const UtilityStatementsDisplay = ({arcUtilityAccountId}) => {
     const result = await fetchUtilityStatements(arcUtilityAccountId);
     setArcUtilityStatements(result)
   };
+
+  // Clear the current Utility Statements if the user re-enters a arcUtilityAccountId
+  useEffect(() => {
+    setArcUtilityStatements(null)
+  }, [arcUtilityAccountId]);
 
   return (
     <div>


### PR DESCRIPTION
We want to CLEAR the page if we re-enter a utility account ID.

Previously, the utility statements and genability account for the OLD Id were still loading on the page 