### PR TITLE
Display statements starting with newest first

### DIFF
--- a/server/arc-client.js
+++ b/server/arc-client.js
@@ -45,7 +45,7 @@ export const getUtilityAccount = async (utilityAccountId) => {
 export const getUtilityStatements = async (utilityAccountId) => {
   const accessToken = await getArcAccessToken();
   const response = await arcadiaApi.get(
-    `/plug/utility_statements?utility_account_id=${utilityAccountId}`,
+    `/plug/utility_statements?utility_account_id=${utilityAccountId}&order=asc`,
     {
       headers: setArcHeaders(accessToken),
     }


### PR DESCRIPTION
I hit an issue where the interval scraper didn't pull back intervals as far back as we had utility statements. This led to an issue where the calculation was not able to pull in any interval data for the utility statement and it showed 0 energy use for the period.

In the future, we may want to display a warning if there statement period of the intervals falls outside of the earliest or latest interval period. That way we don't try to run a calculation when it's not possible.