### PR TITLE
Fixes issue where counterfactuals were different when calculated subsequent times

### DIFF
--- a/server/genability-client.js
+++ b/server/genability-client.js
@@ -92,6 +92,20 @@ export const createTariff = async (
   return result
 };
 
+export const deleteExistingGenabilityProfiles = async (genabilityAccountId) => {
+  const existingUsageProfiles = await getExistingGenabilityProfiles(genabilityAccountId);
+  if (existingUsageProfiles.data.count > 0) {
+    for (const usageProfile of existingUsageProfiles.data.results) {
+      await genabilityApi.delete(`rest/v1/profiles/${usageProfile.profileId}`, { headers: genabilityHeaders })
+    }
+  }
+}
+
+export const getExistingGenabilityProfiles = async (genabilityAccountId) => {
+  const existingUsageProfiles = await genabilityApi.get(`rest/v1/profiles?accountId=${genabilityAccountId}`, { headers: genabilityHeaders });
+  return existingUsageProfiles;
+}
+
 export const createUsageProfileIntervalData = async (
   genabilityAccountId,
   arcUtilityStatement
@@ -120,7 +134,7 @@ export const createUsageProfileIntervalData = async (
     readingData: intervalInfoData,
   };
 
-  genabilityApi.put(`rest/v1/profiles`, body, {
+  await genabilityApi.put(`rest/v1/profiles`, body, {
     headers: genabilityHeaders,
   });
 };

--- a/server/index.js
+++ b/server/index.js
@@ -12,7 +12,8 @@ import {
   createUsageProfileIntervalData,
   createProductionProfileSolarData,
   calculateCurrentBillCost,
-  calculateCurrentBillCostWithoutSolar
+  calculateCurrentBillCostWithoutSolar,
+  deleteExistingGenabilityProfiles
 } from "./genability-client.js";
 dotenv.config();
 
@@ -45,6 +46,9 @@ app.post("/create_genability_account", async (req, res, next) => {
     const arcUtilityAccount = await getUtilityAccount(utilityAccountId);
     const genabilityAccount = await createSwitchAccount(arcUtilityAccount);
     genabilityAccountId = genabilityAccount.accountId;
+
+    // allows implementation to generate usage profiles with each calculation
+    await deleteExistingGenabilityProfiles(genabilityAccountId)
 
     res.json({ genabilityAccount });
     res.status(200);

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -37,6 +37,7 @@ const UtilityStatementElement = ({ arcUtilityStatement }) => {
   const closeModal = () => {
     setOpenModal(false)
     setError(null)
+    setCounterFactualResults(null)
   }
 
   return (


### PR DESCRIPTION
Jon found an issue where recalculating backfactuals produced a different response each time. Very bad. The issue did not appear until recently, which was strange because the backfactual calculations passed a QA test.

The issue turned out to be a missing `await` statement when we were creating usage profiles. Basically what was happening was:

1. The first time a backfactual was run, everything went fine
2. After several backfactuals were run, genability's usage profile creation endpoint became slower (presumably because this is a `PUT`, and the genability usage profile endpoint scans to find overlaps in the usage data), and because we weren't awaiting response, not ALL interval usage records were saved to the genability database before we...
3. Ran the calculate endpoint, which was running with an incomplete set of usage data, leading to variations in the kwh and dollar values (which were based on how many intervals had been written to genability's db at the time the calculation was run)

Awaiting the usage profile creation call solves this problem and produces consistent results in my local testing.