### PR TITLE
Adds dropdown for meter_id

### DIFF
--- a/server/arc-client.js
+++ b/server/arc-client.js
@@ -52,6 +52,23 @@ export const getUtilityAccount = async (utilityAccountId) => {
   }
 };
 
+export const getUtilityMeters = async (utilityAccountId) => {
+  const accessToken = await getArcAccessToken();
+  try {
+    const response = await arcadiaApi.get(
+      `/utility_meters?utility_account_id=${utilityAccountId}&service_types=electric`,
+      {
+        headers: setArcHeaders(accessToken),
+      }
+    );
+    return response.data;
+  } catch (e) {
+    console.log(e.response)
+    throw e
+  }
+
+}
+
 export const getUtilityStatements = async (utilityAccountId) => {
   const accessToken = await getArcAccessToken();
   const response = await arcadiaApi.get(
@@ -78,13 +95,12 @@ export const getUtilityStatement = async (utilityStatementId) => {
 
 export const getIntervalData = async (
   arcUtilityStatementId,
-  arcUtilityAccountId
+  meterId
 ) => {
   const accessToken = await getArcAccessToken();
 
-  // In the future this endpoint will support querying by utility meter
   const response = await arcadiaApi.get(
-    `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_account_id=${arcUtilityAccountId}`,
+    `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_meter_id=${meterId}`,
     {
       headers: setArcHeaders(accessToken),
     }

--- a/server/arc-client.js
+++ b/server/arc-client.js
@@ -48,7 +48,7 @@ export const getUtilityAccount = async (utilityAccountId) => {
       error.response.data.error = "Could not find this utility account, or utility account does not belong to your tenant in this environment"
       error.response.status = 400
     }
-    throw error;
+    throw error.response;
   }
 };
 
@@ -62,11 +62,9 @@ export const getUtilityMeters = async (utilityAccountId) => {
       }
     );
     return response.data;
-  } catch (e) {
-    console.log(e.response)
-    throw e
+  } catch (error) {
+    throw error.response
   }
-
 }
 
 export const getUtilityStatements = async (utilityAccountId) => {

--- a/server/genability-client.js
+++ b/server/genability-client.js
@@ -111,6 +111,9 @@ export const createUsageProfileIntervalData = async (
   arcUtilityStatement,
   meterId
 ) => {
+
+  await deleteExistingGenabilityProfiles(genabilityAccountId);
+
   const intervalData = await getIntervalData(
     arcUtilityStatement.id,
     meterId

--- a/server/genability-client.js
+++ b/server/genability-client.js
@@ -112,8 +112,6 @@ export const createUsageProfileIntervalData = async (
   meterId
 ) => {
 
-  await deleteExistingGenabilityProfiles(genabilityAccountId);
-
   const intervalData = await getIntervalData(
     arcUtilityStatement.id,
     meterId

--- a/server/genability-client.js
+++ b/server/genability-client.js
@@ -108,11 +108,12 @@ export const getExistingGenabilityProfiles = async (genabilityAccountId) => {
 
 export const createUsageProfileIntervalData = async (
   genabilityAccountId,
-  arcUtilityStatement
+  arcUtilityStatement,
+  meterId
 ) => {
   const intervalData = await getIntervalData(
     arcUtilityStatement.id,
-    arcUtilityStatement.utilityAccountId
+    meterId
   );
 
   const intervalInfoData = intervalData.map((interval) => {

--- a/server/index.js
+++ b/server/index.js
@@ -50,9 +50,6 @@ app.post("/create_genability_account", async (req, res, next) => {
     genabilityAccount.utilityMeters = utilityMeters.data;
     genabilityAccountId = genabilityAccount.accountId;
 
-    // allows implementation to generate usage profiles with each calculation
-    await deleteExistingGenabilityProfiles(genabilityAccountId)
-
     res.json({ genabilityAccount });
     res.status(200);
   } catch (error) {
@@ -81,6 +78,10 @@ app.post("/calculate_counterfactual_bill", async (req, res, next) => {
 
     // Step 1: Post Tariff from current UtilityStatement. The genabilityAccountId is set as a Global variable.
     await createTariff(genabilityAccountId, arcUtilityStatement);
+
+    // Step 1a: For the purposes of this reference implementation, we delete existing genability
+    // profiles to produce a fresh calculation each time
+    await deleteExistingGenabilityProfiles(genabilityAccountId)
 
     // Step 2: Update Interval Data Usage Profile
     await createUsageProfileIntervalData(

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ import {
   getUtilityAccount,
   getUtilityStatements,
   getUtilityStatement,
+  getUtilityMeters
 } from "./arc-client.js";
 import {
   createSwitchAccount,
@@ -45,6 +46,8 @@ app.post("/create_genability_account", async (req, res, next) => {
   try {
     const arcUtilityAccount = await getUtilityAccount(utilityAccountId);
     const genabilityAccount = await createSwitchAccount(arcUtilityAccount);
+    const utilityMeters = await getUtilityMeters(utilityAccountId);
+    genabilityAccount.utilityMeters = utilityMeters.data;
     genabilityAccountId = genabilityAccount.accountId;
 
     // allows implementation to generate usage profiles with each calculation
@@ -71,7 +74,7 @@ app.get("/fetch_utility_statements", async (req, res, next) => {
 });
 
 app.post("/calculate_counterfactual_bill", async (req, res, next) => {
-  const { utilityStatementId } = req.body;
+  const { utilityStatementId, meterId } = req.body;
 
   try {
     const arcUtilityStatement = await getUtilityStatement(utilityStatementId);
@@ -82,7 +85,8 @@ app.post("/calculate_counterfactual_bill", async (req, res, next) => {
     // Step 2: Update Interval Data Usage Profile
     await createUsageProfileIntervalData(
       genabilityAccountId,
-      arcUtilityStatement
+      arcUtilityStatement,
+      meterId
     );
     // Step 3: Create/Update Solar Usage Profile
     const solarProductionProfile = await createProductionProfileSolarData(genabilityAccountId);

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -19,7 +19,7 @@ const App = () => {
         error={error}
       />
       { genabilityAccount &&
-        <UtilityStatementsDisplay arcUtilityAccountId={arcUtilityAccountId} setError={setError} error={error}/>
+        <UtilityStatementsDisplay arcUtilityAccountId={arcUtilityAccountId} setError={setError} error={error} meters={genabilityAccount.utilityMeters}/>
       }
       {
         error &&

--- a/src/components/select-meter.jsx
+++ b/src/components/select-meter.jsx
@@ -1,0 +1,7 @@
+const SelectMeter = () => {
+  return (
+    <div>Select your meter</div>
+  )
+}
+
+export default SelectMeter;

--- a/src/components/select-meter.jsx
+++ b/src/components/select-meter.jsx
@@ -1,7 +1,0 @@
-const SelectMeter = () => {
-  return (
-    <div>Select your meter</div>
-  )
-}
-
-export default SelectMeter;

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -8,13 +8,19 @@ import Modal from 'react-modal';
 
 const containerStyle = {
   display: "flex",
-  gap: '20px',
+  gap: "20px",
 }
 
 const titleStyle = {
   display: "flex",
   justifyContent: "space-between",
-  alignItems: 'center'
+  alignItems: "center"
+}
+
+const counterFactualHeaderStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: "5px"
 }
 
 Modal.setAppElement(document.getElementById('root'));
@@ -48,10 +54,13 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
   return (
     <div>
       <JSONPretty id="json-pretty" data={arcUtilityStatement}></JSONPretty>
-      <div>Calculate Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}
-      <select defaultValue={meters[0].id} value={selectedMeterId} onChange={handleMeterSelection}>
+      <div style={counterFactualHeaderStyle}>
+        <div>
+          Calculate Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id} using meter ID:
+        </div>
+        <select value={selectedMeterId} onChange={handleMeterSelection}>
           {meters.map((meter) => (
-            <option key={meter.id} value={meter.id}>Meter Id: {meter.id}</option>
+            <option key={meter.id} value={meter.id}>{meter.id}</option>
           ))}
         </select>
         <button onClick={() => calculate(arcUtilityStatement.id)}>
@@ -60,7 +69,7 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
       </div>
       <Modal isOpen={openModal} appElement={document.getElementById('app')}>
         <div style={titleStyle}>
-          <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}</h3>
+          <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}, Meter Id: ${selectedMeterId}</h3>
           <button onClick={closeModal}>close</button>
         </div>
         <>
@@ -69,7 +78,7 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
               <CounterfactualResults title="Current Cost" results={counterFactualResults.currentCost}></CounterfactualResults>
               <CounterfactualResults title="Current Cost Without Solar" results={counterFactualResults.currentCostWithoutSolar}></CounterfactualResults>
             </div>
-              : error ? <ErrorMessage error={error}/>
+              : error ? <ErrorMessage error={error} />
                 : <p>Loading...</p>
           }
         </>

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -25,7 +25,7 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
   const [error, setError] = useState()
   const [selectedMeterId, setSelectedMeterId] = useState(meters[0].id)
 
-  const handleChange = (e) => {
+  const handleMeterSelection = (e) => {
     setSelectedMeterId(e.target.value)
   }
 
@@ -49,7 +49,7 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
     <div>
       <JSONPretty id="json-pretty" data={arcUtilityStatement}></JSONPretty>
       <div>Calculate Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}
-      <select defaultValue={meters[0].id} value={selectedMeterId} onChange={handleChange}>
+      <select defaultValue={meters[0].id} value={selectedMeterId} onChange={handleMeterSelection}>
           {meters.map((meter) => (
             <option key={meter.id} value={meter.id}>Meter Id: {meter.id}</option>
           ))}

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -69,7 +69,7 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
       </div>
       <Modal isOpen={openModal} appElement={document.getElementById('app')}>
         <div style={titleStyle}>
-          <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}, Meter Id: ${selectedMeterId}</h3>
+          <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}, Meter Id: {selectedMeterId}</h3>
           <button onClick={closeModal}>close</button>
         </div>
         <>

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -19,15 +19,20 @@ const titleStyle = {
 
 Modal.setAppElement(document.getElementById('root'));
 
-const UtilityStatementElement = ({ arcUtilityStatement }) => {
+const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
   const [openModal, setOpenModal] = useState(false)
   const [counterFactualResults, setCounterFactualResults] = useState()
   const [error, setError] = useState()
+  const [selectedMeterId, setSelectedMeterId] = useState(meters[0].id)
+
+  const handleChange = (e) => {
+    setSelectedMeterId(e.target.value)
+  }
 
   const calculate = async (arcUtilityStatementId) => {
     try {
       setOpenModal(true)
-      const result = await calculateCounterfactualBill(arcUtilityStatementId)
+      const result = await calculateCounterfactualBill(arcUtilityStatementId, selectedMeterId)
       setCounterFactualResults(result)
     } catch (error) {
       setError(error.response)
@@ -43,9 +48,16 @@ const UtilityStatementElement = ({ arcUtilityStatement }) => {
   return (
     <div>
       <JSONPretty id="json-pretty" data={arcUtilityStatement}></JSONPretty>
-      <button onClick={() => calculate(arcUtilityStatement.id)}>
-        Calculate Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}
-      </button>
+      <div>Calculate Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}
+      <select defaultValue={meters[0].id} value={selectedMeterId} onChange={handleChange}>
+          {meters.map((meter) => (
+            <option key={meter.id} value={meter.id}>Meter Id: {meter.id}</option>
+          ))}
+        </select>
+        <button onClick={() => calculate(arcUtilityStatement.id)}>
+          Calculate!
+        </button>
+      </div>
       <Modal isOpen={openModal} appElement={document.getElementById('app')}>
         <div style={titleStyle}>
           <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}</h3>

--- a/src/components/utility-statements-display.jsx
+++ b/src/components/utility-statements-display.jsx
@@ -3,9 +3,9 @@ import { fetchUtilityStatements } from "../session.js";
 import UtilityStatementElement from "./utility-statement-element.jsx";
 import { string } from 'prop-types';
 
-const UtilityStatementsDisplay = ({arcUtilityAccountId, setError, error}) => {
+const UtilityStatementsDisplay = ({arcUtilityAccountId, setError, error, meters}) => {
   const [arcUtilityStatements, setArcUtilityStatements] = useState()
-
+  console.log('meterz', meters)
   const setUtilityStatements = async () => {
     try{
       const result = await fetchUtilityStatements(arcUtilityAccountId);
@@ -30,7 +30,7 @@ const UtilityStatementsDisplay = ({arcUtilityAccountId, setError, error}) => {
       {arcUtilityStatements &&
         arcUtilityStatements.data.map(utilityStatement => {
           return(
-           <UtilityStatementElement key={utilityStatement.id} arcUtilityStatement={utilityStatement}/>
+           <UtilityStatementElement key={utilityStatement.id} arcUtilityStatement={utilityStatement} meters={meters}/>
           )
         })
       }

--- a/src/components/utility-statements-display.jsx
+++ b/src/components/utility-statements-display.jsx
@@ -5,7 +5,7 @@ import { string } from 'prop-types';
 
 const UtilityStatementsDisplay = ({arcUtilityAccountId, setError, error, meters}) => {
   const [arcUtilityStatements, setArcUtilityStatements] = useState()
-  console.log('meterz', meters)
+
   const setUtilityStatements = async () => {
     try{
       const result = await fetchUtilityStatements(arcUtilityAccountId);

--- a/src/session.js
+++ b/src/session.js
@@ -28,11 +28,13 @@ export const fetchUtilityStatements = async (utilityAccountId) => {
   }
 };
 
-export const calculateCounterfactualBill = async (arcUtilityStatementId) => {
+export const calculateCounterfactualBill = async (arcUtilityStatementId, selectedMeterId) => {
   try {
     const response = await axios.post(
       `${backend}/calculate_counterfactual_bill`,
-      { utilityStatementId: arcUtilityStatementId },
+      { utilityStatementId: arcUtilityStatementId,
+        meterId: selectedMeterId
+       },
       {
         withCredentials: true,
       }


### PR DESCRIPTION
Ticket: [en-1508](https://arcadiapower.atlassian.net/jira/software/projects/EN/boards/50?selectedIssue=EN-1508)

**What:**
Adds a meter_id selection dropdown the the calculate counterfactual button:

<img width="865" alt="Screen Shot 2022-10-11 at 4 29 10 PM" src="https://user-images.githubusercontent.com/3899696/195192165-6186f189-b68f-4a26-8f4c-4ac2a54b1e78.png">

**Testing**
Grab a utility account id that is associated with more than one electric meter (I've been using `2428377` for my testing):
```
UtilityAccount.joins(:meters).where(meters: {service_type: "electric"})
.group('utility_accounts.id').having('count(utility_id) > 1').for_tenant(5417)
```

Run through the steps of the counterfactual calculation, compare the output of each `meter_id` calculation to make sure they have different values (I've been primarily checking `kwh`).

**Considerations:**
1. Although the meters are stored in our database at the utility account level, I thought it would be clearer in this example to show how the `meter_id`s can be used at the statement level to run interval calculations.
2. I moved the `deleteExistingGenabilityProfiles` function to the main 'calculate' flow because I think it makes more sense to delete profiles each time we run a backfactual rather than each time we create/update a genability account.


