### PR TITLE
En 1716/aggregate all meters remove dropdown

### DIFF
--- a/server/arc-client.js
+++ b/server/arc-client.js
@@ -97,7 +97,9 @@ export const getIntervalData = async (
   meterId
 ) => {
   const accessToken = await getArcAccessToken();
-  const path = meterId ? `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_meter_id=${meterId}` : `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_account_id=${arcUtilityAccountId}`
+  const path = meterId ?
+    `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_meter_id=${meterId}` :
+    `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_account_id=${arcUtilityAccountId}`;
 
   const response = await arcadiaApi.get(
     path,

--- a/server/arc-client.js
+++ b/server/arc-client.js
@@ -52,16 +52,16 @@ export const getUtilityAccount = async (utilityAccountId) => {
   }
 };
 
-export const getUtilityMeters = async (utilityAccountId) => {
+export const getUtilityMeters = async (arcUtilityAccountId) => {
   const accessToken = await getArcAccessToken();
   try {
     const response = await arcadiaApi.get(
-      `/utility_meters?utility_account_id=${utilityAccountId}&service_types=electric`,
+      `/utility_meters?utility_account_id=${arcUtilityAccountId}&service_types=electric`,
       {
         headers: setArcHeaders(accessToken),
       }
     );
-    return response.data;
+    return response.data.data;
   } catch (error) {
     throw error.response
   }
@@ -93,12 +93,14 @@ export const getUtilityStatement = async (utilityStatementId) => {
 
 export const getIntervalData = async (
   arcUtilityStatementId,
+  arcUtilityAccountId,
   meterId
 ) => {
   const accessToken = await getArcAccessToken();
+  const path = meterId ? `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_meter_id=${meterId}` : `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_account_id=${arcUtilityAccountId}`
 
   const response = await arcadiaApi.get(
-    `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_meter_id=${meterId}`,
+    path,
     {
       headers: setArcHeaders(accessToken),
     }

--- a/server/genability-client.js
+++ b/server/genability-client.js
@@ -128,6 +128,7 @@ export const createUsageProfiles = async (arcUtilityStatement, genabilityAccount
       null
     );
   }
+  return meters;
 }
 
 export const createUsageProfileIntervalData = async (
@@ -142,7 +143,7 @@ export const createUsageProfileIntervalData = async (
     meterId
   );
 
-  const intervalInfoData = intervalData.map((interval) => {
+  const transformedIntervalData = intervalData.map((interval) => {
     return {
       fromDateTime: interval.startTime,
       toDateTime: interval.endTime,
@@ -159,7 +160,7 @@ export const createUsageProfileIntervalData = async (
     isDefault: false,
     serviceTypes: "ELECTRICITY",
     sourceId: "ReadingEntry",
-    readingData: intervalInfoData,
+    readingData: transformedIntervalData,
   };
 
   return await genabilityApi.put(`rest/v1/profiles`, body, {

--- a/server/genability-client.js
+++ b/server/genability-client.js
@@ -163,7 +163,7 @@ export const createUsageProfileIntervalData = async (
     readingData: transformedIntervalData,
   };
 
-  return await genabilityApi.put(`rest/v1/profiles`, body, {
+  await genabilityApi.put(`rest/v1/profiles`, body, {
     headers: genabilityHeaders,
   });
 };

--- a/server/index.js
+++ b/server/index.js
@@ -81,7 +81,7 @@ app.post("/calculate_counterfactual_bill", async (req, res, next) => {
     await deleteExistingGenabilityProfiles(genabilityAccountId)
 
     // Step 2: Create Interval Data Usage Profiles
-    await createUsageProfiles(arcUtilityStatement, genabilityAccountId)
+    const metersUsedInCalculation = await createUsageProfiles(arcUtilityStatement, genabilityAccountId)
 
     // Step 3: Create/Update Solar Usage Profile
     const solarProductionProfile = await createProductionProfileSolarData(genabilityAccountId);
@@ -95,6 +95,7 @@ app.post("/calculate_counterfactual_bill", async (req, res, next) => {
     res.json({
       currentCost: currentCost.results[0],
       currentCostWithoutSolar: currentCostWithoutSolar.results[0],
+      metersUsedInCalculation: metersUsedInCalculation
     });
     res.status(200);
   } catch (error) {

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -60,14 +60,24 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
       <Modal isOpen={openModal} appElement={document.getElementById('app')}>
         <div style={titleStyle}>
           <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}, Meter Id: </h3>
+
           <button onClick={closeModal}>close</button>
         </div>
         <>
           {
-            counterFactualResults ? <div style={containerStyle}>
-              <CounterfactualResults title="Current Cost" results={counterFactualResults.currentCost}></CounterfactualResults>
-              <CounterfactualResults title="Current Cost Without Solar" results={counterFactualResults.currentCostWithoutSolar}></CounterfactualResults>
-            </div>
+            counterFactualResults ?
+              (
+                <>
+                  {
+                    counterFactualResults.metersUsedInCalculation.length &&
+                    <div>Meter IDs used in calculation: {counterFactualResults.metersUsedInCalculation.map(meter => meter.id).join(', ')}</div>
+                  }
+                  <div style={containerStyle}>
+                    <CounterfactualResults title="Current Cost" results={counterFactualResults.currentCost}></CounterfactualResults>
+                    <CounterfactualResults title="Current Cost Without Solar" results={counterFactualResults.currentCostWithoutSolar}></CounterfactualResults>
+                  </div>
+                </>
+              )
               : error ? <ErrorMessage error={error} />
                 : <p>Loading...</p>
           }

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -29,16 +29,11 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
   const [openModal, setOpenModal] = useState(false)
   const [counterFactualResults, setCounterFactualResults] = useState()
   const [error, setError] = useState()
-  const [selectedMeterId, setSelectedMeterId] = useState(meters[0].id)
-
-  const handleMeterSelection = (e) => {
-    setSelectedMeterId(e.target.value)
-  }
 
   const calculate = async (arcUtilityStatementId) => {
     try {
       setOpenModal(true)
-      const result = await calculateCounterfactualBill(arcUtilityStatementId, selectedMeterId)
+      const result = await calculateCounterfactualBill(arcUtilityStatementId)
       setCounterFactualResults(result)
     } catch (error) {
       setError(error.response)
@@ -58,18 +53,13 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
         <div>
           Calculate Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id} using meter ID:
         </div>
-        <select value={selectedMeterId} onChange={handleMeterSelection}>
-          {meters.map((meter) => (
-            <option key={meter.id} value={meter.id}>{meter.id}</option>
-          ))}
-        </select>
         <button onClick={() => calculate(arcUtilityStatement.id)}>
           Calculate!
         </button>
       </div>
       <Modal isOpen={openModal} appElement={document.getElementById('app')}>
         <div style={titleStyle}>
-          <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}, Meter Id: {selectedMeterId}</h3>
+          <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}, Meter Id: </h3>
           <button onClick={closeModal}>close</button>
         </div>
         <>

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -59,8 +59,7 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
       </div>
       <Modal isOpen={openModal} appElement={document.getElementById('app')}>
         <div style={titleStyle}>
-          <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}, Meter Id: </h3>
-
+          <h3>Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}</h3>
           <button onClick={closeModal}>close</button>
         </div>
         <>

--- a/src/session.js
+++ b/src/session.js
@@ -28,13 +28,11 @@ export const fetchUtilityStatements = async (utilityAccountId) => {
   }
 };
 
-export const calculateCounterfactualBill = async (arcUtilityStatementId, selectedMeterId) => {
+export const calculateCounterfactualBill = async (arcUtilityStatementId) => {
   try {
     const response = await axios.post(
       `${backend}/calculate_counterfactual_bill`,
-      { utilityStatementId: arcUtilityStatementId,
-        meterId: selectedMeterId
-       },
+      { utilityStatementId: arcUtilityStatementId },
       {
         withCredentials: true,
       }


### PR DESCRIPTION
Jira Ticket: [en-1716](https://arcadiapower.atlassian.net/jira/software/projects/EN/boards/50?selectedIssue=EN-1716)

### Overview
Previously, we allowed users to select a `meterId` for each statement before calculating a backfactual. We decided it was a better use case to "automatically" include all relevant meters in a statement's backfactual calculation and simply display the `meterId`s that we actually used in the calculation:
<img width="642" alt="Screen Shot 2022-10-26 at 9 53 28 AM" src="https://user-images.githubusercontent.com/3899696/198052740-df7e1e75-aeda-4129-ab4b-85cdbe8d254f.png">

### Testing

- You may need to update the Arc Api keys for the internal dev tenant in your `.env` file -- looks like the were rotated at some point yesterday.
- The latest batches of backfactuals are here: [PGE](https://docs.google.com/spreadsheets/d/1PsxxkZAGqUrtriA8EY5gtV9FcaMGBzUc_a7-ye1YrQ0/edit#gid=1303352379), [SCE](https://docs.google.com/spreadsheets/d/1giebzN-7zz7CQ1ILQao-YOHbxzv6qhqn_PNnzpsUBn4/edit#gid=1654416510), [SDGE](https://docs.google.com/spreadsheets/d/15hGACBNkHf76KCyQUJwrnDBQkVTGGzUs2idlQBeFthA/edit#gid=325430866) -- the results of this tool should match the results of those runs.
- For my own testing, I've been using PGE account `2441066` (for multi-meter) and SDGE account `2439374` (for single meter, but you should be able to use any utility account number from the above google docs.
- The `currentTotalCostKwh` in the google doc for a particular statement should match the `kWh` in the calcuation result:
<img width="548" alt="Screen Shot 2022-10-26 at 10 34 41 AM" src="https://user-images.githubusercontent.com/3899696/198055279-13fb7d99-ede7-4138-a9b3-434164485ae7.png">
<img width="1633" alt="Screen Shot 2022-10-26 at 10 36 32 AM" src="https://user-images.githubusercontent.com/3899696/198055809-83dc7650-a086-42e4-a511-b3421a3ef22d.png">

### Considerations
It looks like there's a [bug](https://arcadiapower.slack.com/archives/C03QPJ4Q01Y/p1666298856212029) with the way `isDefault` is getting set on the `usageProfiles. The way I'm grabbing all "non-default" profiles for the calculation gets around the uncertainty of what the `isDefault` value is set to (the default profile is always included in calculations and there's currently no situation in which we'd want to ignore the default profile).
