### PR TITLE
En 1703/add tariff prop inputs to calculation

### DIFF
--- a/server/genability-client.js
+++ b/server/genability-client.js
@@ -222,6 +222,7 @@ export const createProductionProfileSolarData = async (genabilityAccountId) => {
 };
 
 const transformPropertyInputs = (propertyInputs) => {
+  // Properties are applied to the main tariff, which may affect the calculated cost of electricity.
   return propertyInputs.map(propertyInput => {
     return {
       keyName: propertyInput.id,


### PR DESCRIPTION
Jira Ticket: [en-1705](https://arcadiapower.atlassian.net/browse/EN-1705)

### Overview
Adds property inputs to `/calculate` endpoints, which change the final dollar amount calculation.

### Testing
I don't know **_how_** property inputs should affect the dollar amount, but I can verify that they **_do_** affect the dollar amount.

- Test account with property inputs: SDGE UA `2439257`, statementId: `17694225`
- Verify that the dollar amount from this reference implementation is different than the dollar amount from the most recent [csv for SDGE](https://docs.google.com/spreadsheets/d/15hGACBNkHf76KCyQUJwrnDBQkVTGGzUs2idlQBeFthA/edit#gid=325430866)
- You can't necessarily do this with _any_ utility account in the spreadsheet because a lot of them don't have `propertyInputs`, in which case the dollar amount will remain unchanged.

### Considerations
There are a couple different ways to add property inputs (see discussion from [yesterday](https://arcadiapower.slack.com/archives/C040K7ECWTU/p1666798925135229)) -- you can either add them to the account OR throw them in to the request body of the `/calculate` call. I opted for the latter because it seemed like a cleaner way to handle instances where utility statements for a single account have different property inputs (the other way would involve setting time bound property inputs for each statement at the account level).