### PR TITLE
call new intervals by statement id endpoint

### DIFF
--- a/server/arc-client.js
+++ b/server/arc-client.js
@@ -92,14 +92,10 @@ export const getUtilityStatement = async (utilityStatementId) => {
 };
 
 export const getIntervalData = async (
-  arcUtilityStatementId,
-  arcUtilityAccountId,
-  meterId
+  arcUtilityStatementId
 ) => {
   const accessToken = await getArcAccessToken();
-  const path = meterId ?
-    `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_meter_id=${meterId}` :
-    `/plug/utility_intervals?utility_statement_id=${arcUtilityStatementId}&utility_account_id=${arcUtilityAccountId}`;
+  const path = `/plug/utility_statements/${arcUtilityStatementId}/intervals`
 
   const response = await arcadiaApi.get(
     path,

--- a/server/arc-client.js
+++ b/server/arc-client.js
@@ -52,21 +52,6 @@ export const getUtilityAccount = async (utilityAccountId) => {
   }
 };
 
-export const getUtilityMeters = async (arcUtilityAccountId) => {
-  const accessToken = await getArcAccessToken();
-  try {
-    const response = await arcadiaApi.get(
-      `/utility_meters?utility_account_id=${arcUtilityAccountId}&service_types=electric`,
-      {
-        headers: setArcHeaders(accessToken),
-      }
-    );
-    return response.data.data;
-  } catch (error) {
-    throw error.response
-  }
-}
-
 export const getUtilityStatements = async (utilityAccountId) => {
   const accessToken = await getArcAccessToken();
   const response = await arcadiaApi.get(

--- a/server/genability-client.js
+++ b/server/genability-client.js
@@ -138,9 +138,7 @@ export const createUsageProfileIntervalData = async (
 ) => {
 
   const intervalData = await getIntervalData(
-    arcUtilityStatement.id,
-    arcUtilityStatement.utilityAccountId,
-    meterId
+    arcUtilityStatement.id
   );
 
   const transformedIntervalData = intervalData.map((interval) => {

--- a/server/genability-client.js
+++ b/server/genability-client.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import dotenv from "dotenv";
 import dayjs from "dayjs";
 import { env } from "process";
-import { getIntervalData, getUtilityMeters } from "./arc-client.js";
+import { getIntervalData } from "./arc-client.js";
 import { readFile } from 'fs/promises';
 dotenv.config();
 
@@ -106,35 +106,9 @@ export const getExistingGenabilityProfiles = async (genabilityAccountId) => {
   return existingUsageProfiles;
 }
 
-export const createUsageProfiles = async (arcUtilityStatement, genabilityAccountId) => {
-  const meters = await getUtilityMeters(arcUtilityStatement.utilityAccountId)
-  if (meters.length) {
-    // If there are multiple meters associated with the statement period,
-    // we create a usage profile for each meter. All usage profiles will
-    // be used when we run calculations.
-    for (let meter of meters) {
-      await createUsageProfileIntervalData(
-        genabilityAccountId,
-        arcUtilityStatement,
-        meter.id
-      );
-    }
-  } else {
-    // If an account does not have meter-level data,
-    // we attempt to get interval data at the statement level.
-    await createUsageProfileIntervalData(
-      genabilityAccountId,
-      arcUtilityStatement,
-      null
-    );
-  }
-  return meters;
-}
-
 export const createUsageProfileIntervalData = async (
   genabilityAccountId,
   arcUtilityStatement,
-  meterId
 ) => {
 
   const intervalData = await getIntervalData(
@@ -152,9 +126,9 @@ export const createUsageProfileIntervalData = async (
 
   const body = {
     accountId: genabilityAccountId,
-    providerProfileId: `ELECTRICITY_USAGE_UA_${arcUtilityStatement.utilityAccountId}${meterId ? "_METER_" + meterId : '_WITHOUT_METER'}`,
-    profileName: `Interval Data for ${meterId ? 'meter ' + meterId : 'utility_account ' + arcUtilityStatement.utilityAccountId}`,
-    description: `Usage Profile using Interval Data for Utility Account ${arcUtilityStatement.utilityAccountId}${meterId ? " - meter: " + meterId : ""}`,
+    providerProfileId: `ELECTRICITY_USAGE_UA_${arcUtilityStatement.utilityAccountId}`,
+    profileName: `Interval Data for ${'utility_account ' + arcUtilityStatement.utilityAccountId}`,
+    description: `Usage Profile using Interval Data for Utility Account ${arcUtilityStatement.utilityAccountId}`,
     isDefault: false,
     serviceTypes: "ELECTRICITY",
     sourceId: "ReadingEntry",
@@ -252,8 +226,8 @@ export const getExistingNonDefaultProfiles = async (genabilityAccountId, service
   // https://www.switchsolar.io/api-reference/account-api/usage-profile/#examples
   // The first usage profile with a serviceType of 'ELECTRICITY' will automatically be set
   // to isDefault: true, which means it will be used in calculations without the need to specify
-  // its profileId. Here, we want to get all the nonDefault usage profiles in the case of a multi-meter
-  // account so those usage profiles can be included in the calculation by profileId.
+  // its profileId. Here, we want to get any nonDefault usage profiles that may be associated with the account
+  // so those usage profiles can be included in the calculation by profileId.
   const existingUsageProfiles = await getExistingGenabilityProfiles(genabilityAccountId);
   return existingUsageProfiles.data.results.filter(usageProfile => (usageProfile.serviceTypes === serviceType) && (usageProfile.isDefault === false))
 }

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,7 @@ import {
 import {
   createSwitchAccount,
   createTariff,
-  createUsageProfiles,
+  createUsageProfileIntervalData,
   createProductionProfileSolarData,
   calculateCurrentBillCost,
   calculateCurrentBillCostWithoutSolar,
@@ -81,7 +81,7 @@ app.post("/calculate_counterfactual_bill", async (req, res, next) => {
     await deleteExistingGenabilityProfiles(genabilityAccountId)
 
     // Step 2: Create Interval Data Usage Profiles
-    const metersUsedInCalculation = await createUsageProfiles(arcUtilityStatement, genabilityAccountId)
+    await createUsageProfileIntervalData(genabilityAccountId, arcUtilityStatement)
 
     // Step 3: Create/Update Solar Usage Profile
     const solarProductionProfile = await createProductionProfileSolarData(genabilityAccountId);
@@ -94,8 +94,7 @@ app.post("/calculate_counterfactual_bill", async (req, res, next) => {
 
     res.json({
       currentCost: currentCost.results[0],
-      currentCostWithoutSolar: currentCostWithoutSolar.results[0],
-      metersUsedInCalculation: metersUsedInCalculation
+      currentCostWithoutSolar: currentCostWithoutSolar.results[0]
     });
     res.status(200);
   } catch (error) {

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -19,7 +19,7 @@ const App = () => {
         error={error}
       />
       { genabilityAccount &&
-        <UtilityStatementsDisplay arcUtilityAccountId={arcUtilityAccountId} setError={setError} error={error} meters={genabilityAccount.utilityMeters}/>
+        <UtilityStatementsDisplay arcUtilityAccountId={arcUtilityAccountId} setError={setError} error={error} />
       }
       {
         error &&

--- a/src/components/utility-statement-element.jsx
+++ b/src/components/utility-statement-element.jsx
@@ -25,7 +25,7 @@ const counterFactualHeaderStyle = {
 
 Modal.setAppElement(document.getElementById('root'));
 
-const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
+const UtilityStatementElement = ({ arcUtilityStatement }) => {
   const [openModal, setOpenModal] = useState(false)
   const [counterFactualResults, setCounterFactualResults] = useState()
   const [error, setError] = useState()
@@ -34,6 +34,7 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
     try {
       setOpenModal(true)
       const result = await calculateCounterfactualBill(arcUtilityStatementId)
+
       setCounterFactualResults(result)
     } catch (error) {
       setError(error.response)
@@ -51,7 +52,7 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
       <JSONPretty id="json-pretty" data={arcUtilityStatement}></JSONPretty>
       <div style={counterFactualHeaderStyle}>
         <div>
-          Calculate Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id} using meter ID:
+          Calculate Counterfactual Bill for Arc Utility Statement {arcUtilityStatement.id}
         </div>
         <button onClick={() => calculate(arcUtilityStatement.id)}>
           Calculate!
@@ -66,16 +67,10 @@ const UtilityStatementElement = ({ arcUtilityStatement, meters }) => {
           {
             counterFactualResults ?
               (
-                <>
-                  {
-                    counterFactualResults.metersUsedInCalculation.length &&
-                    <div>Meter IDs used in calculation: {counterFactualResults.metersUsedInCalculation.map(meter => meter.id).join(', ')}</div>
-                  }
-                  <div style={containerStyle}>
-                    <CounterfactualResults title="Current Cost" results={counterFactualResults.currentCost}></CounterfactualResults>
-                    <CounterfactualResults title="Current Cost Without Solar" results={counterFactualResults.currentCostWithoutSolar}></CounterfactualResults>
-                  </div>
-                </>
+                <div style={containerStyle}>
+                  <CounterfactualResults title="Current Cost" results={counterFactualResults.currentCost}></CounterfactualResults>
+                  <CounterfactualResults title="Current Cost Without Solar" results={counterFactualResults.currentCostWithoutSolar}></CounterfactualResults>
+                </div>
               )
               : error ? <ErrorMessage error={error} />
                 : <p>Loading...</p>

--- a/src/components/utility-statements-display.jsx
+++ b/src/components/utility-statements-display.jsx
@@ -3,7 +3,7 @@ import { fetchUtilityStatements } from "../session.js";
 import UtilityStatementElement from "./utility-statement-element.jsx";
 import { string } from 'prop-types';
 
-const UtilityStatementsDisplay = ({arcUtilityAccountId, setError, error, meters}) => {
+const UtilityStatementsDisplay = ({arcUtilityAccountId, setError, error}) => {
   const [arcUtilityStatements, setArcUtilityStatements] = useState()
 
   const setUtilityStatements = async () => {
@@ -30,7 +30,7 @@ const UtilityStatementsDisplay = ({arcUtilityAccountId, setError, error, meters}
       {arcUtilityStatements &&
         arcUtilityStatements.data.map(utilityStatement => {
           return(
-           <UtilityStatementElement key={utilityStatement.id} arcUtilityStatement={utilityStatement} meters={meters}/>
+           <UtilityStatementElement key={utilityStatement.id} arcUtilityStatement={utilityStatement} />
           )
         })
       }


### PR DESCRIPTION
Jira ticket: [en-1724](https://arcadiapower.atlassian.net/jira/software/projects/EN/boards/50?selectedIssue=EN-1724)

### What
Instead of getting interval data from the old interval endpoint, we're now getting interval data using the `utility_statement` endpoint, which will provide interval data for the statement period (aggregating multiple meters if need be, so long as they're providing data related to the statement's service period).


### Testing
I pulled a couple `utility_account_id`s from the latest [sdge counterfactuals](https://docs.google.com/spreadsheets/d/15hGACBNkHf76KCyQUJwrnDBQkVTGGzUs2idlQBeFthA/edit#gid=325430866) just to check, and they produced the expected values. Some of them were slightly different, but I assume this is because we're now sending tariff properties along with the main tariff id in this quickstart (and the latest run of the csv generator didn't include the properties). 

I was curious to see what happened if we tried a UA/US.id that didn't have interval data, so I ran `utility_account_id: 2439279` and `statement_id: 17694371` and got the following:
<img width="1392" alt="Screen Shot 2022-11-10 at 10 41 22 AM" src="https://user-images.githubusercontent.com/3899696/201141700-d07c2053-b1b0-42a9-b40e-389dbd9d385b.png">

 

